### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/djbender/number_gaps/security/code-scanning/1](https://github.com/djbender/number_gaps/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow. The best way to do this is to add the block at the root level, immediately after the workflow `name` and before the `on:` key. This will apply the permissions to all jobs in the workflow unless a job overrides them. Since none of the jobs shown require write access to repository contents, issues, or pull requests, the minimal starting point is `contents: read`. This restricts the GITHUB_TOKEN to read-only access to repository contents, which is sufficient for checking out code and running tests or analysis. No additional imports or definitions are required; this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
