### PR TITLE
Pin all GitHub Actions to specific vX.Y.Z versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || '' }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v4.0.0
 
       - name: Build image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@v7.1.0
         with:
           context: .
           push: false
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || '' }}
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.300.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || '' }}
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.300.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
@@ -81,7 +81,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || '' }}
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.300.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
@@ -99,7 +99,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || '' }}
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.300.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
@@ -125,7 +125,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || '' }}
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.300.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
@@ -141,7 +141,7 @@ jobs:
         run: bin/rails test:system
 
       - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         if: failure()
         with:
           name: screenshots

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.1
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -60,7 +60,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -69,6 +69,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@v4.35.1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions in `ci.yml` and `scorecard.yml` to exact `vX.Y.Z` versions instead of floating major tags or SHA refs
- Updates several actions to their latest patch releases

## Changes
| Action | Before | After |
|--------|--------|-------|
| `docker/setup-buildx-action` | `v4` | `v4.0.0` |
| `docker/build-push-action` | `v7` | `v7.1.0` |
| `ruby/setup-ruby` | `v1` | `v1.300.0` |
| `actions/upload-artifact` | `v7.0.0` / SHA | `v7.0.1` |
| `actions/checkout` | SHA (v6.0.1) | `v6.0.2` |
| `ossf/scorecard-action` | SHA (v2.4.3) | `v2.4.3` |
| `github/codeql-action/upload-sarif` | `v4` | `v4.35.1` |