### PR TITLE
Add Dokku predeploy DB connection check

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "dokku": {
+      "predeploy": "bin/rails runner 'ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each { |c| ActiveRecord::Base.establish_connection(c).connection.execute(\"SELECT 1\") }'",
       "postdeploy": "bundle exec rails db:migrate"
     }
   }


### PR DESCRIPTION
## Summary

- Add Dokku `predeploy` script that runs `SELECT 1` against every configured DB for the current Rails env.
- Fails the deploy early if any DB unreachable, before `postdeploy` runs `db:migrate`.
