### PR TITLE
Use with_connection block in Dokku predeploy DB check

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dokku": {
-      "predeploy": "bin/rails runner 'ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each { |c| ActiveRecord::Base.establish_connection(c).connection.execute(\"SELECT 1\") }'",
+      "predeploy": "bin/rails runner 'ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each { |c| ActiveRecord::Base.establish_connection(c).with_connection { |conn| conn.execute(\"SELECT 1\") } }'",
       "postdeploy": "bundle exec rails db:migrate"
     }
   }


### PR DESCRIPTION
## Summary
- Wrap the predeploy `SELECT 1` in `with_connection { |conn| ... }` so the connection is properly checked out and returned to the pool.
- Avoids deprecation warnings around direct `connection.execute` access in newer Rails.
