### PR TITLE
Update nginx.conf.sigil for dokku 0.38 + preload jemalloc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN --mount=type=cache,id=apt-base-${TARGETARCH},target=/var/cache/apt,sharing=l
   apt-get install --yes --no-install-recommends curl libjemalloc2 postgresql-client
   mv /etc/apt/apt.conf.d/docker-clean.bak /etc/apt/apt.conf.d/docker-clean
   bundle config set jobs $(nproc)
+  ldconfig -p | grep -q libjemalloc
 EOF
 
 
@@ -30,7 +31,8 @@ EOF
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development"
+    BUNDLE_WITHOUT="development" \
+    LD_PRELOAD="libjemalloc.so.2"
 
 # Throw-away build stage to reduce size of final image
 FROM base AS build

--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -8,10 +8,23 @@ NOTE: CUSTOM MODIFICATION FROM DEFAULT DOKKU TEMPLATE:
 {{ $listen_port := index $port_map_list 1 }}
 {{ $upstream_port := index $port_map_list 2 }}
 
-{{ if eq $scheme "http" }}
+{{ if or (eq $scheme "http") (eq $scheme "https") }}
+{{ $is_ssl := eq $scheme "https" }}
 server {
+  {{ if $is_ssl }}
+  {{ if eq $.HTTP2_DIRECTIVE_SUPPORTED "true" }}
+  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }} ssl;
+  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} ssl;
+  http2 on;
+  {{ else }}
+  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }} ssl http2;
+  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} ssl http2;
+  {{ end }}
+  {{ else }}
   listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }};
   listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }};
+  {{ end }}
+  {{ if and $is_ssl $.SSL_SERVER_NAME }}server_name {{ $.SSL_SERVER_NAME }}; {{ end }}
   {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
   access_log  {{ $.NGINX_ACCESS_LOG_PATH }}{{ if and ($.NGINX_ACCESS_LOG_FORMAT) (ne $.NGINX_ACCESS_LOG_PATH "off") }} {{ $.NGINX_ACCESS_LOG_FORMAT }}{{ end }};
   error_log   {{ $.NGINX_ERROR_LOG_PATH }};
@@ -23,87 +36,25 @@ server {
   {{ if $.LINGERING_TIMEOUT }}lingering_timeout {{ $.LINGERING_TIMEOUT }};{{end}}
   {{ if $.SEND_TIMEOUT }}send_timeout {{ $.SEND_TIMEOUT }};{{end}}
 
-  location    / {
-
-    gzip on;
-    gzip_min_length  1100;
-    gzip_buffers  4 32k;
-    gzip_types    text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/wasm application/json application/xml application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
-    gzip_vary on;
-    gzip_comp_level  6;
-
-    proxy_pass  http://{{ $.APP }}-{{ $upstream_port }};
-    proxy_http_version 1.1;
-    {{ if $.PROXY_CONNECT_TIMEOUT }}proxy_connect_timeout {{ $.PROXY_CONNECT_TIMEOUT }};{{end}}
-    {{ if $.PROXY_READ_TIMEOUT }}proxy_read_timeout {{ $.PROXY_READ_TIMEOUT }};{{end}}
-    {{ if $.PROXY_SEND_TIMEOUT }}proxy_send_timeout {{ $.PROXY_SEND_TIMEOUT }};{{end}}
-    proxy_buffer_size {{ $.PROXY_BUFFER_SIZE }};
-    proxy_buffering {{ $.PROXY_BUFFERING }};
-    proxy_buffers {{ $.PROXY_BUFFERS }};
-    proxy_busy_buffers_size {{ $.PROXY_BUSY_BUFFERS_SIZE }};
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $http_connection;
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Forwarded-For {{ $.PROXY_X_FORWARDED_FOR }};
-    proxy_set_header X-Forwarded-Port {{ $.PROXY_X_FORWARDED_PORT }};
-    proxy_set_header X-Forwarded-Proto {{ $.PROXY_X_FORWARDED_PROTO }};
-    proxy_set_header X-Request-Start $msec;
-    {{ if $.PROXY_X_FORWARDED_SSL }}proxy_set_header X-Forwarded-Ssl {{ $.PROXY_X_FORWARDED_SSL }};{{ end }}
-  }
-
-  {{ if $.CLIENT_MAX_BODY_SIZE }}client_max_body_size {{ $.CLIENT_MAX_BODY_SIZE }};{{ end }}
-
-  error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
-  location /400-error.html {
-    root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
-    internal;
-  }
-
-  error_page 404 /404-error.html;
-  location /404-error.html {
-    root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
-    internal;
-  }
-
-  error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
-  location /500-error.html {
-    root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
-    internal;
-  }
-  include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
-}
-{{ else if eq $scheme "https"}}
-server {
-  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }} ssl {{ if eq $.HTTP2_SUPPORTED "true" }}http2{{ end }};
-  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} ssl {{ if eq $.HTTP2_SUPPORTED "true" }}http2{{ end }};
-  {{ if $.SSL_SERVER_NAME }}server_name {{ $.SSL_SERVER_NAME }}; {{ end }}
-  {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
-  access_log  {{ $.NGINX_ACCESS_LOG_PATH }}{{ if and ($.NGINX_ACCESS_LOG_FORMAT) (ne $.NGINX_ACCESS_LOG_PATH "off") }} {{ $.NGINX_ACCESS_LOG_FORMAT }}{{ end }};
-  error_log   {{ $.NGINX_ERROR_LOG_PATH }};
-  underscores_in_headers {{ $.NGINX_UNDERSCORE_IN_HEADERS }};
-
+  {{ if $is_ssl }}
   ssl_certificate           {{ $.APP_SSL_PATH }}/server.crt;
   ssl_certificate_key       {{ $.APP_SSL_PATH }}/server.key;
-  ssl_protocols             TLSv1.2 {{ if eq $.TLS13_SUPPORTED "true" }}TLSv1.3{{ end }};
+  ssl_protocols             TLSv1.2 TLSv1.3;
   ssl_prefer_server_ciphers off;
-
-  {{ if $.CLIENT_BODY_TIMEOUT }}client_body_timeout {{ $.CLIENT_BODY_TIMEOUT }};{{end}}
-  {{ if $.CLIENT_HEADER_TIMEOUT }}client_header_timeout {{ $.CLIENT_HEADER_TIMEOUT }};{{end}}
-  {{ if $.KEEPALIVE_TIMEOUT }}keepalive_timeout {{ $.KEEPALIVE_TIMEOUT }};{{end}}
-  {{ if $.LINGERING_TIMEOUT }}lingering_timeout {{ $.LINGERING_TIMEOUT }};{{end}}
-  {{ if $.SEND_TIMEOUT }}send_timeout {{ $.SEND_TIMEOUT }};{{end}}
+  {{ end }}
 
   location    / {
+{{ if $.DOKKU_APP_WEB_LISTENERS }}
 
     gzip on;
     gzip_min_length  1100;
     gzip_buffers  4 32k;
-    gzip_types    text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+    gzip_types    text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/wasm application/json application/graphql-response+json application/xml application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
     gzip_vary on;
     gzip_comp_level  6;
 
     proxy_pass  http://{{ $.APP }}-{{ $upstream_port }};
-    {{ if eq $.HTTP2_PUSH_SUPPORTED "true" }}http2_push_preload on; {{ end }}
+    {{ if and $is_ssl (eq $.HTTP2_PUSH_SUPPORTED "true") }}http2_push_preload on; {{ end }}
     proxy_http_version 1.1;
     {{ if $.PROXY_CONNECT_TIMEOUT }}proxy_connect_timeout {{ $.PROXY_CONNECT_TIMEOUT }};{{end}}
     {{ if $.PROXY_READ_TIMEOUT }}proxy_read_timeout {{ $.PROXY_READ_TIMEOUT }};{{end}}
@@ -120,6 +71,9 @@ server {
     proxy_set_header X-Forwarded-Proto {{ $.PROXY_X_FORWARDED_PROTO }};
     proxy_set_header X-Request-Start $msec;
     {{ if $.PROXY_X_FORWARDED_SSL }}proxy_set_header X-Forwarded-Ssl {{ $.PROXY_X_FORWARDED_SSL }};{{ end }}
+{{ else }}
+    return 502;
+{{ end }}
   }
 
   {{ if $.CLIENT_MAX_BODY_SIZE }}client_max_body_size {{ $.CLIENT_MAX_BODY_SIZE }};{{ end }}
@@ -136,51 +90,50 @@ server {
     internal;
   }
 
+  {{ if $is_ssl }}
   error_page 500 501 503 504 505 506 507 508 509 510 511 /500-error.html;
+  {{ else }}
+  error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+  {{ end }}
   location /500-error.html {
     root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
     internal;
   }
 
+  {{ if $is_ssl }}
   error_page 502 /502-error.html;
   location /502-error.html {
     root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
     internal;
   }
+  {{ end }}
   include {{ $.DOKKU_ROOT }}/.nginx.conf.d/*.conf;
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 }
-{{ else if eq $scheme "grpc"}}
-{{ if eq $.GRPC_SUPPORTED "true"}}{{ if eq $.HTTP2_SUPPORTED "true"}}
+{{ else if or (eq $scheme "grpc") (eq $scheme "grpcs") }}
+{{ if $.DOKKU_APP_WEB_LISTENERS }}
+{{ $is_ssl := eq $scheme "grpcs" }}
 server {
-  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }} http2;
-  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} http2;
-  {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
-  access_log  {{ $.NGINX_ACCESS_LOG_PATH }}{{ if and ($.NGINX_ACCESS_LOG_FORMAT) (ne $.NGINX_ACCESS_LOG_PATH "off") }} {{ $.NGINX_ACCESS_LOG_FORMAT }}{{ end }};
-  error_log   {{ $.NGINX_ERROR_LOG_PATH }};
-  underscores_in_headers {{ $.NGINX_UNDERSCORE_IN_HEADERS }};
-  location    / {
-    grpc_pass  grpc://{{ $.APP }}-{{ $upstream_port }};
-  }
-
-  {{ if $.CLIENT_MAX_BODY_SIZE }}client_max_body_size {{ $.CLIENT_MAX_BODY_SIZE }};{{ end }}
-  include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
-}
-{{ end }}{{ end }}
-{{ else if eq $scheme "grpcs"}}
-{{ if eq $.GRPC_SUPPORTED "true"}}{{ if eq $.HTTP2_SUPPORTED "true"}}
-server {
-  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }} ssl http2;
-  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} ssl http2;
+  {{ if eq $.HTTP2_DIRECTIVE_SUPPORTED "true" }}
+  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }}{{ if $is_ssl }} ssl{{ end }};
+  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }}{{ if $is_ssl }} ssl{{ end }};
+  http2 on;
+  {{ else }}
+  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }}{{ if $is_ssl }} ssl{{ end }} http2;
+  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }}{{ if $is_ssl }} ssl{{ end }} http2;
+  {{ end }}
+  {{ if and $is_ssl $.SSL_SERVER_NAME }}server_name {{ $.SSL_SERVER_NAME }}; {{ end }}
   {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
   access_log  {{ $.NGINX_ACCESS_LOG_PATH }}{{ if and ($.NGINX_ACCESS_LOG_FORMAT) (ne $.NGINX_ACCESS_LOG_PATH "off") }} {{ $.NGINX_ACCESS_LOG_FORMAT }}{{ end }};
   error_log   {{ $.NGINX_ERROR_LOG_PATH }};
   underscores_in_headers {{ $.NGINX_UNDERSCORE_IN_HEADERS }};
 
+  {{ if $is_ssl }}
   ssl_certificate           {{ $.APP_SSL_PATH }}/server.crt;
   ssl_certificate_key       {{ $.APP_SSL_PATH }}/server.key;
-  ssl_protocols             TLSv1.2 {{ if eq $.TLS13_SUPPORTED "true" }}TLSv1.3{{ end }};
+  ssl_protocols             TLSv1.2 TLSv1.3;
   ssl_prefer_server_ciphers off;
+  {{ end }}
 
   location    / {
     grpc_pass  grpc://{{ $.APP }}-{{ $upstream_port }};
@@ -190,7 +143,7 @@ server {
   include {{ $.DOKKU_ROOT }}/.nginx.conf.d/*.conf;
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 }
-{{ end }}{{ end }}
+{{ end }}
 {{ end }}
 {{ end }}
 


### PR DESCRIPTION
## Summary
- **nginx.conf.sigil**: align with dokku 0.38 — adds `DOKKU_APP_WEB_LISTENERS` guard, switches to `HTTP2_DIRECTIVE_SUPPORTED` standalone directive, hardcodes TLS 1.2/1.3, drops legacy `GRPC_SUPPORTED` gate. Custom no-HTTP-redirect behavior preserved.
- **Dockerfile**: add `LD_PRELOAD=libjemalloc.so.2` for Ruby memory allocator (reduces fragmentation under long-running Puma workers).